### PR TITLE
add request Pre Processor

### DIFF
--- a/src/OdooRpc.CoreCLR.Client/Internals/JsonRpcClientFactory.cs
+++ b/src/OdooRpc.CoreCLR.Client/Internals/JsonRpcClientFactory.cs
@@ -12,9 +12,17 @@ namespace OdooRpc.CoreCLR.Client.Internals
 {
     internal class JsonRpcClientFactory : IJsonRpcClientFactory
     {
+        private IWebRequestPreProcessor requestPreProcessor;
+        
+        public JsonRpcClientFactory() : this(null) { }
+        public JsonRpcClientFactory(IWebRequestPreProcessor requestPreProcessor)
+        {
+            this.requestPreProcessor = requestPreProcessor;
+        }
+
         public IJsonRpcClient GetRpcClient(Uri rpcEndpoint)
         {
-            return new JsonRpcWebClient(rpcEndpoint);
+            return new JsonRpcWebClient(rpcEndpoint, requestPreProcessor);
         }
     }
 }

--- a/src/OdooRpc.CoreCLR.Client/OdooRpcClient.cs
+++ b/src/OdooRpc.CoreCLR.Client/OdooRpcClient.cs
@@ -23,6 +23,11 @@ namespace OdooRpc.CoreCLR.Client
         {
         }
 
+        public OdooRpcClient(OdooConnectionInfo connectionInfo, IWebRequestPreProcessor requestPreProcessor)
+            : this(new JsonRpcClientFactory(requestPreProcessor), connectionInfo)
+        {
+        }
+
         internal OdooRpcClient(IJsonRpcClientFactory rpcFactory, OdooConnectionInfo connectionInfo)
         {
             this.RpcFactory = rpcFactory;


### PR DESCRIPTION
With a large number of requests, it sometimes happens that there is a bug with a bad keepalive.
So the preprocessor allows you to disable the keepalive function.